### PR TITLE
Add ability to use http proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ import (
 
 func main() {
 	api := vk.New("ru")
+	// set http proxy
+	api.Proxy = "localhost:8080"
 
 	err := api.Init("TOKEN")
 

--- a/vk.go
+++ b/vk.go
@@ -3,9 +3,11 @@ package vk
 import (
 	"encoding/json"
 	"errors"
-	"github.com/go-resty/resty"
+	"fmt"
 	"log"
 	"os"
+
+	"github.com/go-resty/resty"
 )
 
 // VK struct
@@ -19,6 +21,8 @@ type VK struct {
 	longPoll *longPoll
 
 	Messages *Messages
+
+	Proxy string
 }
 
 // RequestParams struct
@@ -29,6 +33,10 @@ func (client *VK) CallMethod(method string, params RequestParams) ([]byte, error
 	params["access_token"] = client.token
 	params["lang"] = client.lang
 	params["v"] = client.version
+
+	if client.Proxy != "" {
+		resty.SetProxy(fmt.Sprint("http://", client.Proxy))
+	}
 
 	resp, err := resty.R().
 		SetQueryParams(params).


### PR DESCRIPTION
Adding ability to pass proxy server to underlying go-resty package.
For cases, when someone uses api for scrapping without access tokens - in such cases rate limits are quite poor.
